### PR TITLE
🗃 Various improvements in the Prisma schema

### DIFF
--- a/backend/src/prisma/migrations/20230412124454_/migration.sql
+++ b/backend/src/prisma/migrations/20230412124454_/migration.sql
@@ -1,0 +1,13 @@
+/*
+  Warnings:
+
+  - You are about to drop the column `userId` on the `User` table. All the data in the column will be lost.
+  - A unique constraint covering the columns `[name]` on the table `User` will be added. If there are existing duplicate values, this will fail.
+
+*/
+-- AlterTable
+ALTER TABLE "User" DROP COLUMN "userId",
+ALTER COLUMN "last_login" DROP NOT NULL;
+
+-- CreateIndex
+CREATE UNIQUE INDEX "User_name_key" ON "User"("name");

--- a/backend/src/prisma/migrations/20230412140334_/migration.sql
+++ b/backend/src/prisma/migrations/20230412140334_/migration.sql
@@ -1,0 +1,59 @@
+/*
+  Warnings:
+
+  - You are about to drop the column `banUntil` on the `ChannelUser` table. All the data in the column will be lost.
+  - You are about to drop the column `isBan` on the `ChannelUser` table. All the data in the column will be lost.
+  - You are about to drop the column `isMute` on the `ChannelUser` table. All the data in the column will be lost.
+  - You are about to drop the column `last_login` on the `User` table. All the data in the column will be lost.
+  - You are about to drop the `Friends` table. If the table is not empty, all the data it contains will be lost.
+
+*/
+-- DropForeignKey
+ALTER TABLE "Friends" DROP CONSTRAINT "Friends_friendsId_fkey";
+
+-- DropIndex
+DROP INDEX "Game_playerOneId_key";
+
+-- DropIndex
+DROP INDEX "Game_playerTwoId_key";
+
+-- AlterTable
+ALTER TABLE "ChannelUser" DROP COLUMN "banUntil",
+DROP COLUMN "isBan",
+DROP COLUMN "isMute",
+ADD COLUMN     "bannedUntil" TIMESTAMP(3),
+ADD COLUMN     "isBanned" BOOLEAN NOT NULL DEFAULT false,
+ADD COLUMN     "isMuted" BOOLEAN NOT NULL DEFAULT false,
+ALTER COLUMN "isBlocked" SET DEFAULT false;
+
+-- AlterTable
+ALTER TABLE "Game" ALTER COLUMN "mode" SET DEFAULT 'PONG_2D',
+ALTER COLUMN "endedAt" DROP DEFAULT,
+ALTER COLUMN "playerOneScore" SET DEFAULT 0,
+ALTER COLUMN "playerTwoScore" SET DEFAULT 0;
+
+-- AlterTable
+ALTER TABLE "Message" ADD COLUMN     "sentAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP;
+
+-- AlterTable
+ALTER TABLE "User" DROP COLUMN "last_login",
+ADD COLUMN     "lastLogin" TIMESTAMP(3);
+
+-- DropTable
+DROP TABLE "Friends";
+
+-- CreateTable
+CREATE TABLE "Friendship" (
+    "id" TEXT NOT NULL,
+    "userId" TEXT NOT NULL,
+    "addedById" TEXT NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "Friendship_pkey" PRIMARY KEY ("id")
+);
+
+-- AddForeignKey
+ALTER TABLE "Friendship" ADD CONSTRAINT "Friendship_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Friendship" ADD CONSTRAINT "Friendship_addedById_fkey" FOREIGN KEY ("addedById") REFERENCES "User"("id") ON DELETE RESTRICT ON UPDATE CASCADE;

--- a/backend/src/prisma/migrations/20230412144756_compose_pk_for_friendship/migration.sql
+++ b/backend/src/prisma/migrations/20230412144756_compose_pk_for_friendship/migration.sql
@@ -1,0 +1,11 @@
+/*
+  Warnings:
+
+  - The primary key for the `Friendship` table will be changed. If it partially fails, the table could be left without primary key constraint.
+  - You are about to drop the column `id` on the `Friendship` table. All the data in the column will be lost.
+
+*/
+-- AlterTable
+ALTER TABLE "Friendship" DROP CONSTRAINT "Friendship_pkey",
+DROP COLUMN "id",
+ADD CONSTRAINT "Friendship_pkey" PRIMARY KEY ("userId", "addedById");

--- a/backend/src/prisma/schema.prisma
+++ b/backend/src/prisma/schema.prisma
@@ -4,64 +4,67 @@ datasource db {
 }
 
 generator client {
-  provider = "prisma-client-js"
+  provider      = "prisma-client-js"
   binaryTargets = ["native", "debian-openssl-1.1.x", "linux-musl"]
 }
 
 model User {
-  id          String        @id @default(uuid())
-  name        String?
-  avatar      String?
-  status      UserStatus
-  last_login  DateTime
-  createdAt   DateTime      @default(now())
-  updatedAt   DateTime      @updatedAt
-  owner       Channel[]     @relation("owner")
-  playerOne   Game?         @relation("playerOne")
-  playerTwo   Game?         @relation("playerTwo")
-  message     Message[]
-  friends     Friends[]
-  channelUser ChannelUser[]
-  auth        Auth?
-  userId      String?
+  id            String        @id @default(uuid())
+  name          String?       @unique
+  avatar        String?
+  status        UserStatus
+  lastLogin     DateTime?
+  createdAt     DateTime      @default(now())
+  updatedAt     DateTime      @updatedAt
+  ownedChannels Channel[]     @relation("owner")
+  gamesOne      Game[]        @relation("playerOne")
+  gamesTwo      Game[]        @relation("playerTwo")
+  messages      Message[]
+  friendships   Friendship[]  @relation("friendships")
+  addedBy       Friendship[]  @relation("addedBy")
+  channelUsers  ChannelUser[]
+  auth          Auth?
 }
 
 model Auth {
-  userId   String @id 
+  userId   String @id
   user     User   @relation(fields: [userId], references: [id])
   email    String @unique
   password String
 }
 
-model Friends {
-  id        String @id @default(uuid())
-  friends   User   @relation(fields: [friendsId], references: [id])
-  friendsId String
+model Friendship {
+  id        String   @id @default(uuid())
+  user      User     @relation("friendships", fields: [userId], references: [id])
+  userId    String
+  addedBy   User     @relation("addedBy", fields: [addedById], references: [id])
+  addedById String
+  createdAt DateTime @default(now())
 }
 
 model Game {
   id        String     @id @default(uuid())
-  mode      GameMode
+  mode      GameMode   @default(PONG_2D)
   startedAt DateTime   @default(now())
-  endedAt   DateTime?   @default(now())
+  endedAt   DateTime?
   status    GameStatus @default(STARTING)
 
   playerOne      User   @relation("playerOne", fields: [playerOneId], references: [id])
-  playerOneId    String @unique
-  playerOneScore Int
-  playerTwo      User?   @relation("playerTwo", fields: [playerTwoId], references: [id])
-  playerTwoId    String @unique
-  playerTwoScore Int
+  playerOneId    String
+  playerOneScore Int    @default(0)
+  playerTwo      User?  @relation("playerTwo", fields: [playerTwoId], references: [id])
+  playerTwoId    String
+  playerTwoScore Int    @default(0)
 
   socketId String @unique
 }
 
 model Channel {
   id          String        @id @default(uuid())
-  owner       User          @relation("owner", fields: [ownerId], references: [id])
   createdAt   DateTime      @default(now())
   channelType ChannelType
   password    String?
+  owner       User          @relation("owner", fields: [ownerId], references: [id])
   ownerId     String
   messages    Message[]
   users       ChannelUser[]
@@ -77,19 +80,20 @@ model ChannelUser {
 
   role Role
 
-  isBlocked Boolean
-  isBan     Boolean
-  banUntil  DateTime
-  isMute    Boolean
+  isBlocked   Boolean   @default(false)
+  isBanned    Boolean   @default(false)
+  bannedUntil DateTime?
+  isMuted     Boolean   @default(false)
 }
 
 model Message {
-  id        String  @id @default(uuid())
+  id        String   @id @default(uuid())
   content   String
-  sender    User    @relation(fields: [senderId], references: [id])
-  channel   Channel @relation(fields: [channelId], references: [id])
+  sender    User     @relation(fields: [senderId], references: [id])
+  channel   Channel  @relation(fields: [channelId], references: [id])
   channelId String
   senderId  String
+  sentAt    DateTime @default(now())
 }
 
 enum Role {

--- a/backend/src/prisma/schema.prisma
+++ b/backend/src/prisma/schema.prisma
@@ -34,12 +34,13 @@ model Auth {
 }
 
 model Friendship {
-  id        String   @id @default(uuid())
   user      User     @relation("friendships", fields: [userId], references: [id])
   userId    String
   addedBy   User     @relation("addedBy", fields: [addedById], references: [id])
   addedById String
   createdAt DateTime @default(now())
+
+  @@id(fields: [userId, addedById])
 }
 
 model Game {


### PR DESCRIPTION
**Message**
- Ajout d'un champ `sentAt` pour savoir quand le message a été envoyé (et surtout pour pouvoir les ordonner).

**User**
- Suppression du champ `userId` (a priori redondant avec `User.id`).
- Remplacement de relations *OneToOne* à la table `Game` par des relations *OneToMany* (auparavant, un joueur ne pouvait pas jouer plusieurs fois en tant que `PlayerOne` ou `PlayerTwo`, on ne veut pas de ces contraintes d'unicité).
- Renommage des "*relation fields*" ([doc de Prisma](https://www.prisma.io/docs/concepts/components/prisma-schema/relations#relation-fields)) pour plus de clarté. Par exemple, le champ `owner` de la relation `owner` devient `ownedChannels` (puisqu'il correspond à une liste de `Channel`s dont l'utilisateur est propriétaire).
- Le champ `name` répond désormais à une contrainte d'unicité (on ne veut pas pouvoir avoir 2 utilisateurs avec le même nom).

**Game**
- Les scores de départ sont désormais à 0 par défaut.

**Friend**
- Table `Friend` renommée en `Friendship` pour lever toute ambiguïté : une ligne de cette table ne correspond pas à 1 personne mais à 2, en français le terme "amitié" me semble plus adéquat que "ami" pour définir cette relation ("*ManyToMany*"). Ce point est plus subjectif que les autres, on peut faire marche arrière si c'est perturbant !
- Ajout d'une colonne. Chaque ligne de la table pointe vers un utilisateur qui a cliqué sur "*Ajouter en ami*" (`addedBy`) ainsi que vers un autre qui est la cible de l'ajout (`user`).
- Ajout d'un champ `createdAt` car ça ne coûte rien et que c'est une [bonne habitude](https://softwareengineering.stackexchange.com/questions/118489/does-it-make-sense-to-standardize-including-a-created-date-and-last-updated-date) à prendre.
- Suppression de la colonne `id`, la clé primaire de la table est désormais une "*Composite Primary Key*".

**ChannelUser**
- Modifications mineures pour qu'on soit plus proche d'un anglais correct / pour éviter que le correcteur orthographique souligne certains champs. Par exemple `isBan` devient `isBanned`.
- Le champ `bannedUntil` est désormais optionnel (on peut bannir quelqu'un indéfiniment).

**Autres améliorations**
- Application la convention de nommage officiellement recommandée dans la [doc de Prisma](https://www.prisma.io/docs/reference/api-reference/prisma-schema-reference#naming-conventions), c'est à dire `PascalCase` / singulier pour les *model names* et `camelCase` pour les *model fields*. Par exemple, `last_login` devient `lastLogin`.
- Application de la mise en forme par défaut avec [l'extension Prisma de VS Code](https://marketplace.visualstudio.com/items?itemName=Prisma.prisma).